### PR TITLE
Section 2: Loading with Suspense and a Reactive Store from Scratch

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@types/moment": "2.13",
+    "axios": "0.21.1",
     "moment": "2.13",
     "vue": "3.0.11"
   },

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,15 @@
 <template>
   <section class="section">
     <div class="container">
-      <timeline />
+      <suspense>
+        <template #default>
+          <timeline />
+        </template>
+
+        <template #fallback>
+          <spinner />
+        </template>
+      </suspense>
     </div>
   </section>
 </template>
@@ -9,11 +17,13 @@
 <script lang="ts">
 import { defineComponent } from 'vue';
 import Timeline from './components/Timeline.vue';
+import Spinner from './components/Spinner.vue';
 
 export default defineComponent({
   name: 'App',
   components: {
-    Timeline
+    Timeline,
+    Spinner
   }
 });
 </script>

--- a/src/components/Spinner.vue
+++ b/src/components/Spinner.vue
@@ -1,0 +1,3 @@
+<template>
+  <progress class="progress is-primary is-small" />
+</template>

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -30,11 +30,6 @@ import TimelinePost from './TimelinePost.vue';
 
 type Period = 'Today' | 'This Week' | 'This Month'
 
-function delay() {
-  return new Promise(res => {
-    setTimeout(res, 2000)
-  })
-}
 
 export default defineComponent({
   name: 'Timeline',
@@ -43,10 +38,14 @@ export default defineComponent({
     TimelinePost
   },
   async setup() {
-    await delay()
     const periods = ['Today', 'This Week', 'This Month']
     const currentPeriod = ref<Period>('Today')
     const store = useStore()
+
+    if (!store.getState().posts.loaded) {
+      await store.fetchPosts()
+    }
+
     const allPosts: Post[] = store.getState().posts.ids.reduce<Post[]>((acc, id) => {
       const thePost = store.getState().posts.all.get(id)
       if (!thePost) {

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -24,7 +24,8 @@
 <script lang="ts">
 import { defineComponent, ref, computed } from 'vue';
 import moment from 'moment';
-import { today, thisWeek, thisMonth } from '../mocks'
+import { Post } from '../mocks'
+import { useStore } from '../store'
 import TimelinePost from './TimelinePost.vue';
 
 type Period = 'Today' | 'This Week' | 'This Month'
@@ -45,8 +46,16 @@ export default defineComponent({
     await delay()
     const periods = ['Today', 'This Week', 'This Month']
     const currentPeriod = ref<Period>('Today')
+    const store = useStore()
+    const allPosts: Post[] = store.getState().posts.ids.reduce<Post[]>((acc, id) => {
+      const thePost = store.getState().posts.all.get(id)
+      if (!thePost) {
+        throw Error('This post was not found')
+      }
+      return acc.concat(thePost)
+    }, [])
     const posts = computed(() => {
-      return [today, thisWeek, thisMonth].filter(post => {
+      return allPosts.filter(post => {
         if (currentPeriod.value === 'Today') {
           return post.created.isAfter(moment().subtract(1, 'day'))
         }

--- a/src/components/Timeline.vue
+++ b/src/components/Timeline.vue
@@ -29,13 +29,20 @@ import TimelinePost from './TimelinePost.vue';
 
 type Period = 'Today' | 'This Week' | 'This Month'
 
+function delay() {
+  return new Promise(res => {
+    setTimeout(res, 2000)
+  })
+}
+
 export default defineComponent({
   name: 'Timeline',
 
   components: {
     TimelinePost
   },
-  setup() {
+  async setup() {
+    await delay()
     const periods = ['Today', 'This Week', 'This Month']
     const currentPeriod = ref<Period>('Today')
     const posts = computed(() => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,22 @@
 import { createApp } from 'vue'
 import App from './App.vue'
+import axios from 'axios'
+import { thisMonth, thisWeek, today } from './mocks'
+
+function delay() {
+  return new Promise(res => {
+    setTimeout(res, 2000)
+  })
+}
+
+// @ts-ignore
+axios.get = async (url: string) => {
+  if (url === '/posts') {
+    await delay()
+    return Promise.resolve({
+      data: [today, thisWeek, thisMonth]
+    })
+  }
+}
 
 createApp(App).mount('#app')

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -9,7 +9,7 @@ export interface Post {
 export const today: Post = {
   id: '1',
   title: 'Today',
-  created: moment()
+  created: moment().subtract(1, 'second')
 }
 
 export const thisWeek: Post = {

--- a/src/store.ts
+++ b/src/store.ts
@@ -42,14 +42,11 @@ class Store {
   }
 }
 const all = new Map<string, Post>()
-all.set(today.id, today)
-all.set(thisWeek.id, thisWeek)
-all.set(thisMonth.id, thisMonth)
 
 const store = new Store({
   posts: {
     all,
-    ids: [today.id, thisWeek.id, thisMonth.id],
+    ids: [],
     loaded: false
   }
 })

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,6 +1,6 @@
 import { reactive, readonly } from 'vue'
 import axios from 'axios'
-import { Post } from './mocks'
+import { Post, today, thisWeek, thisMonth } from './mocks'
 
 interface State {
   posts: PostsState
@@ -41,13 +41,24 @@ class Store {
     this.state.posts.loaded = true
   }
 }
+const all = new Map<string, Post>()
+all.set(today.id, today)
+all.set(thisWeek.id, thisWeek)
+all.set(thisMonth.id, thisMonth)
 
 const store = new Store({
   posts: {
-    all: new Map(),
-    ids: [],
+    all,
+    ids: [today.id, thisWeek.id, thisMonth.id],
     loaded: false
   }
 })
+
+// use 
+// composable
+// provide inject
+export function useStore() {
+  return store
+}
 
 store.getState().posts.loaded

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,7 +1,18 @@
 import { reactive, readonly } from 'vue'
+import { Post } from './mocks'
 
 interface State {
-  test: string
+  posts: PostsState
+}
+
+interface PostsState {
+  // o(n)
+  ids: string[]
+
+  // o(1)
+  all: Map<string, Post>
+
+  loaded: boolean
 }
 
 class Store {
@@ -14,12 +25,14 @@ class Store {
   getState() {
     return readonly(this.state)
   }
-
-  updateTest(test: string) {
-    this.state.test = test
-  }
 }
 
 const store = new Store({
-  test: 'test'
+  posts: {
+    all: new Map(),
+    ids: [],
+    loaded: false
+  }
 })
+
+store.getState().posts.loaded

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,0 +1,25 @@
+import { reactive, readonly } from 'vue'
+
+interface State {
+  test: string
+}
+
+class Store {
+  private state: State
+
+  constructor(initial: State) {
+    this.state = reactive(initial)
+  }
+
+  getState() {
+    return readonly(this.state)
+  }
+
+  updateTest(test: string) {
+    this.state.test = test
+  }
+}
+
+const store = new Store({
+  test: 'test'
+})

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,4 +1,5 @@
 import { reactive, readonly } from 'vue'
+import axios from 'axios'
 import { Post } from './mocks'
 
 interface State {
@@ -24,6 +25,20 @@ class Store {
 
   getState() {
     return readonly(this.state)
+  }
+
+  async fetchPosts() {
+    const response = await axios.get<Post[]>('/posts')
+    const postsState: PostsState = {
+      ids: [],
+      all: new Map,
+      loaded: true
+    }
+    for (const post of response.data) {
+      this.state.posts.ids.push(post.id)
+      this.state.posts.all.set(post.id, post)
+    }
+    this.state.posts.loaded = true
   }
 }
 

--- a/tests/unit/example.spec.ts
+++ b/tests/unit/example.spec.ts
@@ -1,16 +1,44 @@
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 import Timeline from '../../src/components/Timeline.vue'
 import { today, thisWeek, thisMonth } from '../../src/mocks'
 
+jest.mock('axios', () => ({
+  get: (url: string) => {
+    return Promise.resolve({
+      data: [today, thisWeek, thisMonth]
+    })
+  }
+}))
+
+function mountTimeline() {
+  return mount({
+    components: { Timeline },
+    template: `
+      <suspense>
+        <template  #default>
+          <timeline />
+        </template>
+        <template #fallback>
+          Loading...
+        </template>
+      </suspense>
+    `
+  })
+}
+
 describe('Timeline.vue', () => {
-  it('renders today post default', () => {
-    const wrapper = mount(Timeline)
+  it('renders today post default', async () => {
+    const wrapper = mountTimeline()
+    // nextTick -> Vue internal promises
+    // axios -> flushPromises
+    await flushPromises()
 
     expect(wrapper.html()).toContain(today.created.format('Do MMM'))
   })
 
   it('update when the period is click', async () => {
-    const wrapper = mount(Timeline)
+    const wrapper = mountTimeline()
+    await flushPromises()
 
     await wrapper.get('[data-test="This Week"]').trigger('click')
 
@@ -19,7 +47,8 @@ describe('Timeline.vue', () => {
   })
 
   it('update when the period is click', async () => {
-    const wrapper = mount(Timeline)
+    const wrapper = mountTimeline()
+    await flushPromises()
 
     await wrapper.get('[data-test="This Month"]').trigger('click')
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1464,6 +1464,13 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
+axios@0.21.1:
+  version "0.21.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.1.tgz#22563481962f4d6bde9a76d516ef0e5d3c09b2b8"
+  integrity sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -3667,7 +3674,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
 
-follow-redirects@^1.0.0:
+follow-redirects@^1.0.0, follow-redirects@^1.10.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.1.tgz#d9114ded0a1cfdd334e164e6662ad02bfd91ff43"
   integrity sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==


### PR DESCRIPTION
# キーワード

* Vue3 Composition API
* vue-test-utils
* TypeScript

## Vue3 Composition API

### Suspense

* コンポーネントが正しくレンダリングされる前に、何かしら非同期のリクエストを実行する。
* `default` スロットを表示できる場合は表示し、そうでない場合は `fallback` スロットを表示する。

#### リンク

* https://v3.ja.vuejs.org/guide/migration/suspense.html#%E3%82%A4%E3%83%B3%E3%83%88%E3%83%AD%E3%82%BF%E3%82%99%E3%82%AF%E3%82%B7%E3%83%A7%E3%83%B3

### Store

* 複数のインスタンスで共有されるべき状態がある場合に適用するパターン。
* 状態を変化させる `action` をすべて `store` 自身の中に置き、中央集権的な状態管理をすることによって、どのような種類の状態変化が起こりうるのか、またそれらがどのようにトリガーされるのか、といったことの理解が容易になる。

#### リンク

* https://v3.ja.vuejs.org/guide/state-management.html

### ref vs reactive

#### ref() Use-Case

You'll always use `ref()` for primitives, but `ref()` is good for objects that need to be reassigned, like an array.

```js
setup() {
    const blogPosts = ref([]);
    return { blogPosts };
}
getBlogPosts() {
    this.blogPosts.value = await fetchBlogPosts();
}
```

The above with `reactive()` would require reassigning a property instead of the whole object.

```js
setup() {
    const blog = reactive({ posts: [] });
    return { blog };
}
getBlogPosts() {
    this.blog.posts = await fetchBlogPosts();
}
```

#### reactive() Use-Case

A good use-case for `reactive()` is a group of primitives that belong together:

```js
const person = reactive({
  name: 'Albert',
  age: 30,
  isNinja: true,
});
```

the code above feels more logical than

```js
const name = ref('Albert');
const age = ref(30);
const isNinja = ref(true);
```

#### リンク

* https://stackoverflow.com/questions/61452458/ref-vs-reactive-in-vue-3

### readonly

* リアクティブオブジェクト(`ref` や `reactive`)の変更を追跡しながらも、アプリケーションのある場所からの変更は防ぎたい場合に使用する。

```js
import { reactive, readonly } from 'vue'

const original = reactive({ count: 0 })

const copy = readonly(original)

// original を変更すると copy 側の依存ウォッチャが発動します
original.count++

// copy を変更しようとすると失敗し、警告が表示されます
copy.count++ // warning: "Set operation on key 'count' failed: target is readonly."
```

#### リンク

* https://v3.ja.vuejs.org/guide/reactivity-fundamentals.html#readonly-%E3%81%A6%E3%82%99%E3%83%AA%E3%82%A2%E3%82%AF%E3%83%86%E3%82%A3%E3%83%95%E3%82%99%E3%82%AA%E3%83%95%E3%82%99%E3%82%B7%E3%82%99%E3%82%A7%E3%82%AF%E3%83%88%E3%81%AE%E5%A4%89%E6%9B%B4%E3%82%92%E9%98%B2%E3%81%8F%E3%82%99

## vue-test-utils

### $nextTick

* アサーションが行われる前に確実に各 `Promise` が `resolve` するために、 `done` と組み合わせて使う。
* テストが完了したことをテストランナーに知らせるために `done` を使う。
* `fetchResults` 内の `Promise` が `resolve` した後にアサーションを呼びたい。 

```js
<template>
  <button @click="fetchResults" />
</template>

<script>
  import axios from 'axios'

  export default {
    data() {
      return {
        value: null
      }
    },

    methods: {
      async fetchResults() {
        const response = await axios.get('mock/service')
        this.value = response.data
      }
    }
  }
</script>
```

```js
import { shallowMount } from '@vue/test-utils'
import Foo from './Foo'
jest.mock('axios')

it('fetches async when a button is clicked', done => {
  const wrapper = shallowMount(Foo)
  wrapper.find('button').trigger('click')
  wrapper.vm.$nextTick(() => {
    expect(wrapper.vm.value).toBe('value')
    done()
  })
})
```

### flushPromises

```js
import { shallowMount } from '@vue/test-utils'
import flushPromises from 'flush-promises'
import Foo from './Foo'
jest.mock('axios')

it('fetches async when a button is clicked', async () => {
  const wrapper = shallowMount(Foo)
  wrapper.find('button').trigger('click')
  await flushPromises()
  expect(wrapper.vm.value).toBe('value')
})
```

#### リンク

* https://vue-test-utils.vuejs.org/ja/guides/testing-async-components.html

### jest.mock

* 実際にAPIにアクセスせずにテストする。
  * もしそのようなテストを作れば、遅くて壊れやすいテストになってしまう
* `axios` モジュールを自動的にモックすることができる。


```js
// users.test.js
import axios from 'axios';
import Users from './users';

jest.mock('axios');

test('should fetch users', () => {
  const users = [{name: 'Bob'}];
  const resp = {data: users};
  axios.get.mockResolvedValue(resp);

  // or you could use the following depending on your use case:
  // axios.get.mockImplementation(() => Promise.resolve(resp))

  return Users.all().then(data => expect(data).toEqual(users));
});
```

#### リンク

* https://jestjs.io/ja/docs/mock-functions#%E3%83%A2%E3%82%B8%E3%83%A5%E3%83%BC%E3%83%AB%E3%81%AE%E3%83%A2%E3%83%83%E3%82%AF

## TypeScript

### interface

* オブジェクトの構造の型定義を宣言する。

```ts
// Sample A
declare var myPoint: { x: number; y: number; };

// Sample B
interface Point {
    x: number; y: number;
}
declare var myPoint: Point;
```

#### リンク

* https://typescript-jp.gitbook.io/deep-dive/type-system/interfaces

### Map

* キーと値の組み合わせからなる抽象データ型。
* 他のプログラミング言語の文脈では辞書やハッシュマップ、連想配列などと呼ばれる。

```js
const map = new Map();
// 新しい要素の追加
map.set("key", "value1");
console.log(map.size); // => 1
console.log(map.get("key")); // => "value1"
// 要素の上書き
map.set("key", "value2");
console.log(map.get("key")); // => "value2"
// キーの存在確認
console.log(map.has("key")); // => true
console.log(map.has("foo")); // => false
```

#### リンク

* https://jsprimer.net/basic/map-and-set/#map

### axios generic get method

```ts
get<T = any, R = AxiosResponse<T>>(url: string, config?: AxiosRequestConfig): Promise<R>;
```

```ts
// Example
interface User {
    id: number;
    firstName: string;
}


axios.get<User[]>('http://localhost:8080/admin/users')
        .then(response => {
            console.log(response.data);
            setUserList( response.data );
        });
```

#### リンク

* https://github.com/axios/axios/blob/master/index.d.ts#L140